### PR TITLE
Updated display for count > 1M

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -82,7 +82,7 @@ const IndexPage = () => {
         casesString = `${cases}`;
 
         if ( cases > 1000000 ) {
-          casesString = `${casesString.slice( 0, -6 )}M+`;
+          casesString = `${casesString.slice( 0, -6 )}.${casesString.slice( -6, -5 )}M+`;
         } else if ( cases > 1000 ) {
           casesString = `${casesString.slice( 0, -3 )}K+`;
         }


### PR DESCRIPTION
Instead of #M it will now show as #.#M (e.g 1.1M). Before, the preview red bubble would just show 1M, even though the count is actively growing. This better shows the spread of the pandemic by showing how many of hundreds of thousands the count is increasing by